### PR TITLE
Turn off output buffering in early returns.

### DIFF
--- a/includes/controller/class-plugins.php
+++ b/includes/controller/class-plugins.php
@@ -159,8 +159,7 @@ class Plugins extends \AspireExplorer\Model\Singleton {
 		);
 
 		if ( is_wp_error( $api_response ) ) {
-			echo wp_kses_post( wpautop( 'Error fetching plugin information. Please try again later.' ) );
-			return;
+			return wp_kses_post( wpautop( 'Error fetching plugin information. Please try again later.' ) );
 		}
 
 		ob_start();

--- a/includes/controller/class-plugins.php
+++ b/includes/controller/class-plugins.php
@@ -122,12 +122,12 @@ class Plugins extends \AspireExplorer\Model\Singleton {
 
 		if ( is_wp_error( $api_response ) ) {
 			echo wp_kses_post( wpautop( 'Error fetching plugins. Please try again later.' ) );
-			return;
+			return ob_get_clean();
 		}
 
 		if ( empty( $api_response->plugins ) ) {
 			echo wp_kses_post( wpautop( 'No plugins found for your search.' ) );
-			return;
+			return ob_get_clean();
 		}
 
 		Utilities::include_file(


### PR DESCRIPTION
# Pull Request

## What changed?

- `Plugins::archive_the_content()` now calls `ob_get_clean()` at every early return to ensure that output buffering is turned off and that the method returns a string as documented.
- The early return in `Plugins::single_the_content()` now returns `wp_kses_post()`, as output buffering has not yet been started.

## Why did it change?

- Output buffering was not being properly closed.
- The early returns caused these methods to return `null` rather than a `string` as documented.

## Did you fix any specific issues?

Fixes #5 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

