### PR TITLE
Remove cases of duplicate screen reader text

### DIFF
--- a/includes/views/plugins/archive/plugin.php
+++ b/includes/views/plugins/archive/plugin.php
@@ -78,7 +78,6 @@ if ( $plugin_info->is_fair_plugin() ) {
 				rel="noopener noreferrer"
 				aria-label="<?php esc_attr_e( 'Download', 'aspireexplorer' ); ?> <?php echo esc_attr( $plugin_info->get_name() ); ?> <?php esc_attr_e( 'plugin', 'aspireexplorer' ); ?>">
 				<span class="dashicons dashicons-download" aria-hidden="true"></span>
-				<span class="screen-reader-text"><?php esc_html_e( 'Download', 'aspireexplorer' ); ?></span>
 				<?php esc_html_e( 'Download', 'aspireexplorer' ); ?>
 			</a>
 		</p>

--- a/includes/views/plugins/single/plugin.php
+++ b/includes/views/plugins/single/plugin.php
@@ -92,7 +92,7 @@ if ( $plugin_info->is_fair_plugin() ) {
 			<ul>
 				<?php
 				if ( $plugin_info->is_fair_plugin() ) {
-					echo '<li class="plugin-meta-item fair-plugin"><strong><span class="screen-reader-text">' . esc_html__( 'Plugin DID:', 'aspireexplorer' ) . '</span>Plugin DID:</strong> <code>' . esc_html( $plugin_did ) . '</code></li>';
+					echo '<li class="plugin-meta-item fair-plugin"><strong>Plugin DID:</strong> <code>' . esc_html( $plugin_did ) . '</code></li>';
 				}
 				?>
 				<?php
@@ -112,7 +112,7 @@ if ( $plugin_info->is_fair_plugin() ) {
 						$value = implode( ', ', $value );
 					}
 					$label = esc_html( ucfirst( str_replace( '_', ' ', $key ) ) );
-					echo '<li class="plugin-meta-item"><strong><span class="screen-reader-text">' . sprintf( esc_html__( '%s:', 'aspireexplorer' ), $label ) . '</span>' . $label . ':</strong> ' . esc_html( $value ) . '</li>';
+					echo '<li class="plugin-meta-item"><strong>' . $label . ':</strong> ' . esc_html( $value ) . '</li>';
 				}
 				?>
 			</ul>

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -112,7 +112,7 @@ if ( isset( $sections['description'] ) ) {
 						$value = implode( ', ', $value );
 					}
 					$label = esc_html( $key );
-					echo '<li class="theme-meta-item"><strong><span class="screen-reader-text">' . sprintf( esc_html__( '%s:', 'aspireexplorer' ), $label ) . '</span>' . $label . ':</strong> ' . esc_html( $value ) . '</li>';
+					echo '<li class="theme-meta-item"><strong>' . $label . ':</strong> ' . esc_html( $value ) . '</li>';
 				}
 				?>
 			</ul>
@@ -149,7 +149,7 @@ if ( isset( $sections['description'] ) ) {
 				<ul class="theme-tags">
 					<?php
 					foreach ( $theme_info->get_tags() as $theme_tag ) {
-						echo '<li class="theme-tag"><span class="screen-reader-text">' . esc_html__( 'Tag:', 'aspireexplorer' ) . ' </span><span aria-label="' . esc_attr__( 'Tag', 'aspireexplorer' ) . ': ' . esc_attr( $theme_tag ) . '">' . esc_html( $theme_tag ) . '</span></li>';
+						echo '<li class="theme-tag"><span class="screen-reader-text">' . esc_html__( 'Tag:', 'aspireexplorer' ) . ' </span>' . esc_html( $theme_tag ) . '</li>';
 					}
 					?>
 				</ul>


### PR DESCRIPTION
# Pull Request

## What changed?

Removed several instances of `.screen-reader-text` classes and one `aria-label` wrapper.

## Why did it change?

The text was duplicated, which would cause this to be read twice by screen reader users.

## Did you fix any specific issues?

#68 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

