### PR TITLE
Replace target="_blank" with download on package links

### DIFF
--- a/includes/views/plugins/single/plugin.php
+++ b/includes/views/plugins/single/plugin.php
@@ -45,7 +45,7 @@ if ( $plugin_info->is_fair_plugin() ) {
 			?>
 		</div>
 		<div class="entry-download">
-			<a href="<?php echo esc_url( $plugin_info->get_download_link() ); ?>" class="button button-primary" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-download"></span> Download</a>
+			<a href="<?php echo esc_url( $plugin_info->get_download_link() ); ?>" class="button button-primary" download rel="noopener noreferrer"><span class="dashicons dashicons-download"></span> Download</a>
 		</div>
 	</header>
 	<div class="entry-main">

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -38,7 +38,6 @@ if ( isset( $sections['description'] ) ) {
 		<div class="entry-title">
 			<h2 class="theme-title"><?php echo esc_html( $theme_info->get_name() ); ?></h2>
 			<p class="theme-author">by <?php echo esc_html( $theme_info->get_author( 'display_name' ) ); ?></p>
-			<p class="theme-version">Version: <?php echo esc_html( $theme_info->get_version() ); ?></p>
 		</div>
 		<div class="entry-preview">
 			<?php

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -56,7 +56,7 @@ if ( isset( $sections['description'] ) ) {
 			</a>
 		</div>
 		<div class="entry-download">
-			<a href="<?php echo esc_url( $theme_info->get_download_link() ); ?>" class="button button-primary" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-download"></span> <?php esc_html_e( 'Download', 'aspireexplorer' ); ?></a>
+			<a href="<?php echo esc_url( $theme_info->get_download_link() ); ?>" class="button button-primary" download rel="noopener noreferrer"><span class="dashicons dashicons-download"></span> <?php esc_html_e( 'Download', 'aspireexplorer' ); ?></a>
 		</div>
 	</header>
 	<div class="entry-main">


### PR DESCRIPTION
# Pull Request

## What changed?

Removed the `_blank` attribute and added the `download` attribute to the download link in single plugin and theme pages.

## Why did it change?

The `download` attribute forces the browser to initiate a direct file download, rather than navigating to a new page or a tab displaying binary content.

By adopting `download`, the use of `target="_blank"` becomes unnecessary and confusing, as the user doesn't need to be redirected to a new tab to begin the download.

## Did you fix any specific issues?

https://github.com/fairpm/website-content/issues/30

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

