### PR TITLE
Eliminate duplicate 'Version' label in package metadata

### DIFF
--- a/includes/views/plugins/single/plugin.php
+++ b/includes/views/plugins/single/plugin.php
@@ -37,7 +37,6 @@ if ( $plugin_info->is_fair_plugin() ) {
 		<div class="entry-title">
 			<h2 class="plugin-title"><?php echo esc_html( $plugin_info->get_name() ); ?></h2>
 			<p class="plugin-author">by <?php echo esc_html( $plugin_info->get_author( 'display_name' ) ); ?></p>
-			<p class="plugin-version">Version: <?php echo esc_html( $plugin_info->get_version() ); ?></p>
 			<?php
 			if ( $plugin_info->is_fair_plugin() ) {
 				echo '<p class="plugin-fair">' . esc_html__( 'This plugin is available via FAIR repository.', 'aspireexplorer' ) . '</p>';

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -38,7 +38,6 @@ if ( isset( $sections['description'] ) ) {
 		<div class="entry-title">
 			<h2 class="theme-title"><?php echo esc_html( $theme_info->get_name() ); ?></h2>
 			<p class="theme-author">by <?php echo esc_html( $theme_info->get_author( 'display_name' ) ); ?></p>
-			<p class="theme-version">Version: <?php echo esc_html( $theme_info->get_version() ); ?></p>
 		</div>
 		<div class="entry-preview">
 			<?php


### PR DESCRIPTION
# Pull Request

## What changed?

The duplicate `Version` field below the package title has been removed, as the information is already displayed in the sidebar metadata.

## Why did it change?

The redundant `Version` field under the package title was creating visual clutter. By removing this duplicate, we ensure the version information is presented only once in the sidebar metadata.

## Did you fix any specific issues?

No

## Before and After

| Before | After |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/4c8ebb96-35f3-4fd2-9469-f2e7a81bc72e) | ![After](https://github.com/user-attachments/assets/49ed92f1-1e7a-4bab-892f-334961cb4007) |


## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

