### PR TITLE
Apply Fetchpriority High to Plugin and Theme Banner

### DIFF
--- a/includes/views/plugins/single/plugin.php
+++ b/includes/views/plugins/single/plugin.php
@@ -31,7 +31,7 @@ if ( $plugin_info->is_fair_plugin() ) {
 ?>
 <main class="single-plugin-card">
 	<banner class="entry-banner">
-		<img class="plugin-banner" src="<?php echo esc_url( $banner_url ); ?>" alt="Plugin Banner">
+		<img class="plugin-banner" src="<?php echo esc_url( $banner_url ); ?>" alt="Plugin Banner" fetchpriority="high">
 	</banner>
 	<header class="entry-header">
 		<div class="entry-title">

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -32,7 +32,7 @@ if ( isset( $sections['description'] ) ) {
 ?>
 <main class="single-theme-card">
 	<banner class="entry-banner">
-		<img class="theme-banner" src="<?php echo esc_url( $theme_screenshot ); ?>" alt="Theme Banner">
+		<img class="theme-banner" src="<?php echo esc_url( $theme_screenshot ); ?>" alt="Theme Banner" fetchpriority="high">
 	</banner>
 	<header class="entry-header">
 		<div class="entry-title">


### PR DESCRIPTION
# Pull Request

## What changed?

Apply the `fetchpriority="high"` attribute to the main image on the single plugins and themes pages.

## Why did it change?

The main image is the most important visual element. By adding `fetchpriority="high"`, we instruct the browser to prioritize the download of this resource over others, which is crucial for the LCP (Largest Contentful Paint) performance metric.

## Did you fix any specific issues?

No

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

