### PR TITLE
Change Accordions to use details - summary for Themes

### DIFF
--- a/includes/views/plugins/single/plugin.php
+++ b/includes/views/plugins/single/plugin.php
@@ -77,8 +77,8 @@ if ( $plugin_info->is_fair_plugin() ) {
 				$is_first = true;
 				foreach ( $sections as $section => $content ) {
 					echo '<details class="section-item" id="section-item-' . esc_attr( $section ) . '" ' . esc_attr( ( $is_first ) ? 'open' : '' ) . '>';
-					echo '<summary role="button" aria-expanded="' . esc_attr( ( $is_first ) ? 'true' : 'false' ) . '">' . esc_html( ucfirst( $section ) ) . '</summary>';
-					echo '<div class="details-content" id="details-content-' . esc_attr( $section ) . '">' . wp_kses_post( $content ) . '</div>';
+						echo '<summary role="button" aria-expanded="' . esc_attr( ( $is_first ) ? 'true' : 'false' ) . '">' . esc_html( ucfirst( $section ) ) . '</summary>';
+						echo '<div class="details-content" id="details-content-' . esc_attr( $section ) . '">' . wp_kses_post( $content ) . '</div>';
 					echo '</details>';
 					if ( $is_first ) {
 						$is_first = false;

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -82,12 +82,15 @@ if ( isset( $sections['description'] ) ) {
 						return $pos_a - $pos_b;
 					}
 				);
+				$is_first = true;
 				foreach ( $sections as $section => $content ) {
-					echo '<div class="accordion-item" id="accordion-item-' . esc_attr( $section ) . '">';
-					echo '<input type="radio" name="accordions" id="section-' . esc_attr( $section ) . '" ' . checked( $section, array_key_first( $sections ), false ) . '>';
-					echo '<label for="section-' . esc_attr( $section ) . '" aria-label="' . esc_attr( sprintf( __( '%s section', 'aspireexplorer' ), ucfirst( $section ) ) ) . '">' . esc_html( ucfirst( $section ) ) . '</label>';
-					echo '<div class="accordion-content" id="accordion-content-' . esc_attr( $section ) . '" aria-labelledby="section-' . esc_attr( $section ) . '">' . wp_kses_post( $content ) . '</div>';
-					echo '</div>';
+					echo '<details class="section-item" id="section-item-' . esc_attr( $section ) . '" ' . esc_attr( ( $is_first ) ? 'open' : '' ) . '>';
+						echo '<summary role="button" aria-expanded="' . esc_attr( ( $is_first ) ? 'true' : 'false' ) . '">' . esc_html( ucfirst( $section ) ) . '</summary>';
+						echo '<div class="details-content" id="details-content-' . esc_attr( $section ) . '">' . wp_kses_post( $content ) . '</div>';
+					echo '</details>';
+					if ( $is_first ) {
+						$is_first = false;
+					}
 				}
 			}
 			?>


### PR DESCRIPTION
Change Accordions to use details - summary for Themes

# Pull Request

## What changed?

Change Accordions to use details - summary for Themes

## Why did it change?

Layout was broken for themes after plugins layout was updated

## Did you fix any specific issues?

Fixes #64 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

