### PR TITLE
Change main element to div

### DIFF
--- a/includes/views/plugins/archive/plugins.php
+++ b/includes/views/plugins/archive/plugins.php
@@ -5,7 +5,7 @@ $current_page     = $args['current_page'] ?? 1;
 $total_results    = $args['total_results'] ?? 0;
 $total_pages      = $args['total_pages'] ?? 1;
 ?>
-<main class="archive-plugin-card">
+<div class="archive-plugin-card">
 	<div class="plugin-results-count">
 		<p id="plugin-results-count-text" aria-hidden="true">
 			<?php
@@ -66,4 +66,4 @@ $total_pages      = $args['total_pages'] ?? 1;
 		}
 		?>
 	</div>
-</main>
+</div>

--- a/includes/views/plugins/single/plugin.php
+++ b/includes/views/plugins/single/plugin.php
@@ -29,7 +29,7 @@ if ( $plugin_info->is_fair_plugin() ) {
 	$plugin_did = esc_attr( $fair_data['id'] );
 }
 ?>
-<main class="single-plugin-card">
+<div class="single-plugin-card">
 	<banner class="entry-banner">
 		<img class="plugin-banner" src="<?php echo esc_url( $banner_url ); ?>" alt="Plugin Banner" fetchpriority="high">
 	</banner>
@@ -146,4 +146,4 @@ if ( $plugin_info->is_fair_plugin() ) {
 			</div>
 		</aside>
 	</div>
-</main>
+</div>

--- a/includes/views/themes/archive/themes.php
+++ b/includes/views/themes/archive/themes.php
@@ -5,7 +5,7 @@ $current_page     = $args['current_page'] ?? 1;
 $total_results    = $args['total_results'] ?? 0;
 $total_pages      = $args['total_pages'] ?? 1;
 ?>
-<main class="archive-theme-card">
+<div class="archive-theme-card">
 	<div class="theme-results-count">
 		<p id="theme-results-count-text" aria-hidden="true">
 			<?php
@@ -66,4 +66,4 @@ $total_pages      = $args['total_pages'] ?? 1;
 		}
 		?>
 	</div>
-</main>
+</div>

--- a/includes/views/themes/single/theme.php
+++ b/includes/views/themes/single/theme.php
@@ -30,7 +30,7 @@ if ( isset( $sections['description'] ) ) {
 	$description = $theme_info->get_description();
 }
 ?>
-<main class="single-theme-card">
+<div class="single-theme-card">
 	<banner class="entry-banner">
 		<img class="theme-banner" src="<?php echo esc_url( $theme_screenshot ); ?>" alt="Theme Banner" fetchpriority="high">
 	</banner>
@@ -158,4 +158,4 @@ if ( isset( $sections['description'] ) ) {
 			</div>
 		</aside>
 	</div>
-</main>
+</div>


### PR DESCRIPTION
main to div to avoid repeating main element in themes.

# Pull Request

## What changed?

Replacing main element with a div element to avoid repeating main element which is usually part of the theme

## Why did it change?

Fix HTML

## Did you fix any specific issues?

Fixes #71 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

