### PR TITLE
Adding a placeholder to the main packages page data on single package…

### DIFF
--- a/includes/controller/class-packages.php
+++ b/includes/controller/class-packages.php
@@ -127,7 +127,7 @@ class Packages {
 		if ( isset( $wp_query->query[ $this->asset_slug_var ] ) )  {
 			// If we have a post and it is our packages page: add a filterable placeholder for the post title.
 			if (! empty( $posts ) && $this->target_page_slug === $posts[0]->post_name ) {
-				$posts[0]->post_title = 'Plugins: {single-package-title}';
+				$posts[0]->post_title = $posts[0]->post_title . ': {single-package-title}';
 			}
 		}
 


### PR DESCRIPTION
… WPQueries

# Pull Request

## What changed?

Added the_posts action to update the packages page title to include a placeholder for any single package query (after the posts have been fetched).

Updated the_title to replace the placeholder with the actual package name.

## Why did it change?

We could not filter the_title because when the filter is calles, there is no difference between the packages page or the single package (as the main query on a single package will return the packages page for both).

We probably can use this type of placeholders for future theme feature requests or bug fixes. Like: adding SEO description (if we'd want to).

## Did you fix any specific issues?

#78 Fixing the_title being greedy and altering any title on a single package page.

## Best practices?

As we are de facto out of the native WP flow, think it's OK to alter post data directly when needed.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

