### PR TITLE
Only filter titles within the looped content

### DIFF
--- a/includes/controller/class-packages.php
+++ b/includes/controller/class-packages.php
@@ -192,6 +192,10 @@ class Packages {
 	 * Filter the_title for asset page.
 	 */
 	public function the_title( $title ) {
+		if ( ! in_the_loop() ) {
+			return $title;
+		}
+
 		if ( ! is_page( $this->target_page_slug ) ) {
 			return $title;
 		}


### PR DESCRIPTION
# Pull Request

## What changed?

Added an in_the_loop() check to exclude titles occuring outside of the loop being filtered.

## Why did it change?

We want to overwrite the main content title (h1), but no titles used in menu items etc.

## Did you fix any specific issues?

#78 , on fair.pm, it requires a fix in the parent theme too: https://github.com/fairpm/fair-parent-theme/pull/20/

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

