### PR TITLE
Support for Github Assets

### DIFF
--- a/includes/model/class-assetinfo.php
+++ b/includes/model/class-assetinfo.php
@@ -463,7 +463,25 @@ class AssetInfo {
 	 * @return string|null URL to asset ZIP or null.
 	 */
 	public function get_download_link() {
-		return filter_var( $this->download_link, FILTER_VALIDATE_URL ) ? $this->download_link : null;
+		$download_link = filter_var( $this->download_link, FILTER_VALIDATE_URL ) ? $this->download_link : false;
+		if (
+			false !== $download_link &&
+			'' !== trim( $download_link ) &&
+			(
+				( $this->is_fair_plugin() ) ||
+				( ! str_ends_with( $download_link, '.zip' ) )
+			)
+		) {
+			$download_link = add_query_arg(
+				[
+					'ae_download' => $download_link,
+					'ae_package'  => $this->get_slug(),
+					'ae_nonce'    => wp_create_nonce( 'ae_download_nonce' ),
+				],
+				home_url()
+			);
+		}
+		return $download_link;
 	}
 
 	/**


### PR DESCRIPTION
Support for Github Assets

# Pull Request

## What changed?

Support for Github Assets which require specific headers to provide downloadable files

## Why did it change?

Support for Github Assets which require specific headers to provide downloadable files, also renames the downloaded file to the package name instad of a randon asset id.

## Did you fix any specific issues?

Fixes #44 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

