### PR TITLE
Remove the target attribute and replace with download on archive pages

### DIFF
--- a/includes/views/plugins/archive/plugin.php
+++ b/includes/views/plugins/archive/plugin.php
@@ -74,7 +74,7 @@ if ( $plugin_info->is_fair_plugin() ) {
 		<p class="entry-download">
 			<a href="<?php echo esc_url( $plugin_info->get_download_link() ); ?>"
 				class="button button-primary"
-				target="_blank"
+				download
 				rel="noopener noreferrer"
 				aria-label="<?php esc_attr_e( 'Download', 'aspireexplorer' ); ?> <?php echo esc_attr( $plugin_info->get_name() ); ?> <?php esc_attr_e( 'plugin', 'aspireexplorer' ); ?>">
 				<span class="dashicons dashicons-download" aria-hidden="true"></span>

--- a/includes/views/themes/archive/theme.php
+++ b/includes/views/themes/archive/theme.php
@@ -71,7 +71,7 @@ if ( empty( $theme_screenshot ) ) {
 		<p class="entry-download">
 			<a href="<?php echo esc_url( $theme_info->get_download_link() ); ?>"
 				class="button button-primary"
-				target="_blank"
+				download
 				rel="noopener noreferrer">
 				<span class="dashicons dashicons-download" aria-hidden="true"></span>
 				<?php esc_html_e( 'Download', 'aspireexplorer' ); ?>


### PR DESCRIPTION
Follow up to https://github.com/aspirepress/AspireExplorer/commit/6533df3ef1f22b75f7d349dcb54b5b60d9900a1e

# Pull Request

## What changed?

Also swaps `target="_blank"` for `download` on package archive screens.

## Why did it change?

Omitted from prior PR.


## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

